### PR TITLE
drop aws_security_group_rule attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ module "alb" {
   vpc     = aws_vpc.this
   subnets = [aws_subnet.private_a, aws_subnet.private_b]
 
-  ingress_security_groups = {
-    some-service = aws_security_group.some_service
-  }
-
   target_group = aws_lb_target_group.example
 
   tags = {

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -14,10 +14,6 @@ module "alb" {
     { id = "subnet-12345678" },
   ]
 
-  ingress_security_groups = {
-    some-service = { id = "sg-12345678" }
-  }
-
   target_group = { arn = "arn:aws:elasticloadbalancing:local:123456789012:targetgroup/some-service/0123456789abcdef" }
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -15,22 +15,6 @@ resource "aws_security_group" "this" {
   }
 }
 
-resource "aws_security_group_rule" "ingress" {
-  for_each = var.ingress_security_groups
-
-  security_group_id = aws_security_group.this.id
-
-  type                     = "ingress"
-  source_security_group_id = each.value.id
-  protocol                 = "tcp"
-  from_port                = var.ingress_port
-  to_port                  = var.ingress_port
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_security_group_rule" "egress" {
   security_group_id = aws_security_group.this.id
 

--- a/variables.tf
+++ b/variables.tf
@@ -5,18 +5,6 @@ variable "ingress_port" {
   default = 80
 }
 
-variable "ingress_security_groups" {
-  description = "Map of security groups the ALB will receive requests from"
-
-  type = map(
-    object({
-      id = string
-    })
-  )
-
-  default = {}
-}
-
 variable "name" {
   description = "Name of the ALB"
 


### PR DESCRIPTION
The attribute `aws_security_group_rule` is not in use currently. 
Therefore we are deprecating it to simplify the terraform module.