### PR TITLE
BREAKING CHANGE: ALB drops invalid header fields by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -36,6 +36,8 @@ resource "aws_lb" "this" {
 
   load_balancer_type = "application"
 
+  drop_invalid_header_fields = var.drop_invalid_header_fields
+
   internal        = true
   subnets         = var.subnets[*].id
   security_groups = [aws_security_group.this.id]

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,10 @@
+variable "drop_invalid_header_fields" {
+  description = "Specify if the ALB should drop invalid header fields"
+
+  type    = bool
+  default = true
+}
+
 variable "ingress_port" {
   description = "The port the ALB will listen to"
 


### PR DESCRIPTION
Sets up the ALB to drop invalid header fields by default.

See the [AWS provider documentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb.html#drop_invalid_header_fields) and [this article](https://repost.aws/knowledge-center/elb-alb-drop-not-valid-headers) from AWS Knowledge Center.