### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,5 @@ module "alb" {
   subnets = [aws_subnet.private_a, aws_subnet.private_b]
 
   target_group = aws_lb_target_group.example
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -16,7 +16,7 @@ module "alb" {
 
   target_group = { arn = "arn:aws:elasticloadbalancing:local:123456789012:targetgroup/some-service/0123456789abcdef" }
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "this" {
 
   tags = merge({
     Name = "LB: ${var.name}"
-  }, var.tags)
+  }, var.default_tags, var.security_group_tags)
 
   lifecycle {
     create_before_destroy = true
@@ -42,7 +42,7 @@ resource "aws_lb" "this" {
   subnets         = var.subnets[*].id
   security_groups = [aws_security_group.this.id]
 
-  tags = var.tags
+  tags = merge(var.default_tags, var.lb_tags)
 }
 
 resource "aws_lb_listener" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,52 +1,84 @@
-variable "drop_invalid_header_fields" {
-  description = "Specify if the ALB should drop invalid header fields"
+variable "default_tags" {
+  type    = map(string)
+  default = {}
 
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
+variable "drop_invalid_header_fields" {
   type    = bool
   default = true
+
+  description = <<EOS
+Specify if the ALB should drop invalid header fields.
+EOS
 }
 
 variable "ingress_port" {
-  description = "The port the ALB will listen to"
-
   type    = number
   default = 80
+
+  description = <<EOS
+The port the ALB will listen to.
+EOS
+}
+
+variable "lb_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the ALB.
+EOS
 }
 
 variable "name" {
-  description = "Name of the ALB"
-
   type = string
+
+  description = <<EOS
+Name of the ALB.
+EOS
+}
+
+variable "security_group_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to the security group.
+EOS
 }
 
 variable "subnets" {
-  description = "List of subnets the ALB will be created in"
-
   type = list(
     object({
       id = string
     })
   )
-}
 
-variable "tags" {
-  description = "Map of tags to assign to all resources supporting tags (in addition to the `Name` tag)"
-
-  type    = map(string)
-  default = {}
+  description = <<EOS
+List of subnets the ALB will be created in.
+EOS
 }
 
 variable "target_group" {
-  description = "Target group all requests to the ALB will be forwarded to"
-
   type = object({
     arn = string
   })
+
+  description = <<EOS
+Target group all requests to the ALB will be forwarded to.
+EOS
 }
 
 variable "vpc" {
-  description = "VPC the ALB and the security group will be created in"
-
   type = object({
     id = string
   })
+
+  description = <<EOS
+VPC the ALB and the security group will be created in.
+EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.