### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,5 @@ module "alb" {
   subnets = [aws_subnet.private_a, aws_subnet.private_b]
 
   target_group = aws_lb_target_group.example
-
-  tags = {
-    app = "example"
-    env = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -16,7 +16,7 @@ module "alb" {
 
   target_group = { arn = "arn:aws:elasticloadbalancing:local:123456789012:targetgroup/some-service/0123456789abcdef" }
 
-  tags = {
+  default_tags = {
     app = "some-service"
     env = "production"
   }

--- a/main.tf
+++ b/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "this" {
 
   tags = merge({
     Name = "LB: ${var.name}"
-  }, var.tags)
+  }, var.default_tags)
 
   lifecycle {
     create_before_destroy = true
@@ -42,7 +42,7 @@ resource "aws_lb" "this" {
   subnets         = var.subnets[*].id
   security_groups = [aws_security_group.this.id]
 
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_lb_listener" "this" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "drop_invalid_header_fields" {
   type    = bool
   default = true
@@ -33,15 +42,6 @@ variable "subnets" {
 
   description = <<EOS
 List of subnets the ALB will be created in.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }
 


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.